### PR TITLE
Add PHP version requirement

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@ Contributors: nofearinc, devrix, hofmannsven, metodiew
 Tags: plugin, localhost, development, production, notice, toolbar, staging
 Requires at least: 3.1
 Tested up to: 4.5
+Requires PHP: 5.6
 Stable tag: 1.0
 License: GPLv2 or later
 


### PR DESCRIPTION
Add a PHP version requirement as introduced on [Make WordPress](https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/) with at least PHP 5.6 according to the [currently supported PHP versions](http://php.net/supported-versions.php).